### PR TITLE
Use main branch for w3c interop reporter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "file-size": "^1.0.0",
     "jsonld-document-loader": "^1.1.0",
     "mocha": "^8.3.2",
-    "mocha-w3c-interop-reporter": "github:digitalbazaar/mocha-w3c-interop-reporter#extend-helpers",
+    "mocha-w3c-interop-reporter": "github:digitalbazaar/mocha-w3c-interop-reporter",
     "mochawesome": "^6.2.2",
     "node-cbor": "^5.0.4",
     "require-dir": "^1.2.0",


### PR DESCRIPTION
This should fix an install error related to the mocha w3c interop reporter (the branch this project was using was merged into main). This might not fix all install errors (bbs+ is not building on my mac).

https://github.com/w3c-ccg/vdl-test-suite/runs/5803069880?check_suite_focus=true

